### PR TITLE
Reword confusing reference to importing

### DIFF
--- a/export.md
+++ b/export.md
@@ -6,7 +6,7 @@ Tropy items can be exported as [JSON-LD](https://json-ld.org/), as well as to [O
 
 To export from Tropy, right-click on an item in the item table. From the right-click menu, select _Export Item &gt; JSON-LD_. This action will open a dialog box, where you can save your JSON file onto your computer. To export multiple items, Ctrl/Command+click or Shift+click to select multiple items. Then right-click and select _Export Selected Items_.
 
-At present, Tropy only exports metadata to JSON-LD, not associated photos. Your photos still exist outside Tropy as well, since importing in Tropy copies your photos.
+At present, Tropy only exports metadata to JSON-LD, not associated photos. Your photos still exist outside Tropy as well, since importing into Tropy leaves your original photos in place.
 
 ### [To Omeka S](//omeka.md) {#omeka}
 


### PR DESCRIPTION
The reference to copying makes it sound like Tropy doesn’t leave the original versions of images alone.