### PR TITLE
Delete redundant Omeka information

### DIFF
--- a/export.md
+++ b/export.md
@@ -1,13 +1,9 @@
 ## Export from Tropy
 
-Tropy items can be exported as [JSON-LD](https://json-ld.org/), as well as to [Omeka S](http://omeka.org/s/).
+Tropy items can be exported as [JSON-LD](https://json-ld.org/), as well as to [Omeka S](http://omeka.org/s/) and CVS via plugins.
 
 ### To JSON-LD
 
 To export from Tropy, right-click on an item in the item table. From the right-click menu, select _Export Item &gt; JSON-LD_. This action will open a dialog box, where you can save your JSON file onto your computer. To export multiple items, Ctrl/Command+click or Shift+click to select multiple items. Then right-click and select _Export Selected Items_.
 
 At present, Tropy only exports metadata to JSON-LD, not associated photos. Your photos still exist outside Tropy as well, since importing in Tropy copies your photos.
-
-### [To Omeka S](//omeka.md) {#omeka}
-
-Export to Omeka S occurs through the Omeka plugin. In order to use it, you will need an existing Omeka S installation and access to the API information.


### PR DESCRIPTION
Exporting via plugins has its own section immediately after this one, so the explicit reference to Omeka isn’t needed here. Also added cvs reference to plugins mention in the first graf.