### PR TITLE
Escape `~` in date ranges

### DIFF
--- a/before-you-begin/metadata.md
+++ b/before-you-begin/metadata.md
@@ -71,7 +71,7 @@ _Property used_: `purl.org/dc/elements/1.1/date`
 
 If you use ISO format, your date will automatically reformat to be more easily readable.
 
-To indicate an uncertain date, use ~ before or the date \(e.g., ~1802, or ~1802-01-01; 1802~ or 1802-01-01~ to indicate uncertainty about the day\). Your date will reformat to include "c." This feature is still evolving and more complex date format support is planned.
+To indicate an uncertain date, use ~ before or the date \(e.g., \~1802, or \~1802-01-01; 1802\~ or 1802-01-01\~ to indicate uncertainty about the day\). Your date will reformat to include "c." This feature is still evolving and more complex date format support is planned.
 
 _Note_: You may want to describe a source in terms of dates in addition to when it was created, such as the date or dates referred to in the source, or dates when a source was modified or edited. In these cases, there are additional metadata properties that you can use to add additional date fields to your template, such as `purl.org/dc/elements/1.1/coverage`, `purl.org/dc/terms/created`, or `purl.org/dc/terms/modified`.
 


### PR DESCRIPTION
Gitbook interprets ~ as strikethrough, so the docs about date ranges render weirdly
![image](https://github.com/tropy/docs/assets/12828913/a2a6f28c-874f-4038-b54a-05be9871d0fd)

I'm hoping that gitbook respects escape characters in the same way as GitHub does, but I don't think I have a way to build a local preview to check?